### PR TITLE
support for 0x08 (backspace character)

### DIFF
--- a/src/down_std.ml
+++ b/src/down_std.ml
@@ -486,8 +486,8 @@ module Tty = struct
       | 0x0A -> `Bytes "\n"
       | 0x0D -> `Enter
       | 0x1B -> read_esc readc
+      | 0x7F | 0x08 -> `Backspace
       | b when b <= 0x1F -> `Ctrl (b + 0x60)
-      | 0x7F -> `Backspace
       | b -> `Bytes (read_bytes readc b)
       in
       Some i


### PR DESCRIPTION
Dear Daniel,

for me and my terminal (xterm on FreeBSD), the backspace character does not work in down. I looked in [notty input code](https://github.com/pqwy/notty/blob/d832fc65b84971bc71217555f274b0106a9fcc81/src/notty.ml#L767), and when `0x08` is taken as `` `Backspace ``, it actually works!