### PR TITLE
Relax the cursor position requirement in getting doc/types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-
+- Relax the cursor position requirement in getting doc/types for identifiers
 - Be more subtle when line edition is not available. Let the Down
   API work reasonably well and/or error gracefully (#17).
 - Less clever, but more robust, end of user input detection (#14).

--- a/doc/manual.mld
+++ b/doc/manual.mld
@@ -207,8 +207,8 @@ hit TAB:
 # List.con
 ]}
 
-To get the type and documentation of an identifier put your cursor over the
-identifier and hit [C-t]:
+Hitting [C-t] will give you the type and documentation of the identifier
+currently down your cursor (or right before it):
 {[
 # List.append
 

--- a/src/down.ml
+++ b/src/down.ml
@@ -512,21 +512,14 @@ module Ocaml = struct
 
   let id_span s ~start =
     let slen = String.length s in
-    if start < 0 || start >= slen then None else
-    if not (id_path_char s.[start]) then None else
-    let id_start =
-      let rec loop s i =
-        if i >= 0 && id_path_char s.[i] then loop s (i - 1) else i + 1
-      in
-      loop s start
-    in
+    let valid i = i >= 0 && i < slen in
+    let rec loop i c y n = if valid i && c i then loop (i + y) c y n else i + n in
     let id_end =
-      let rec loop s i =
-        if i < String.length s && id_path_char s.[i] then loop s (i + 1)
-        else i - 1
-      in
-      loop s start
-    in
+      if valid start && id_path_char s.[start]
+      then loop (start + 1) (fun i -> id_path_char s.[i]) 1 (-1)
+      else loop (start - 1) (fun i -> not (id_path_char s.[i])) (-1) 0 in
+    if not (valid id_end) then None else
+    let id_start = loop (id_end - 1) (fun i -> id_path_char s.[i]) (-1) 1 in
     Some (String.sub s id_start (id_end - id_start + 1))
 end
 


### PR DESCRIPTION
I found myself constantly have to move cursor backwards in order to check
the type or doc of an identifier which I've just typed in (or tab completed),
as my cursor will always be after that identifier in these cases. And after my
inquiry is done, I'll again have to move the cursor back to where it was.

It feels ergonomic if we can additionally allow the cursor to be right after
an identifier when a user requests its doc.

The patch relaxes a little more than the above use cases, in that if there are
other things (other than spaces) e.g. brackets between the cursor and the
last identifier, it will work the same. I feel this is a no harm addition and
brings a bit more convenience probably.

Signed-off-by: Zheng Li <dev@zheng.li>