### PR TITLE
tab completion fix, fixes #21

### DIFF
--- a/src/down.ml
+++ b/src/down.ml
@@ -904,9 +904,13 @@ module Ocp_index = struct
       let id = String.trim (List.hd (String.split_on_char '\t' r)) in
       if id = "" then acc else Ctrie.add (string_to_list id) (Some ()) acc
     in
-    let ids = List.fold_left add_id Ctrie.empty results in
+    let res =
+      List.fold_right (fun r acc -> if r = "" then acc else r :: acc)
+        results []
+    in
+    let ids = List.fold_left add_id Ctrie.empty res in
     let word, _ = Ctrie.find_fork (string_to_list word) ids in
-    (string_of_list word, results)
+    (string_of_list word, res)
 
   let finish_single_complete = function
   | "" -> ""
@@ -926,8 +930,8 @@ module Ocp_index = struct
       Result.bind (Result.map_error snd @@ Cmd.read (complete_cmd w)) @@
       fun cs -> match String.trim cs with
       | "" -> Ok (w, [])
-      | s ->
-          match complete_word w (Txt.lines s) with
+      | _ ->
+          match complete_word w (Txt.lines cs) with
           | w, ([_] as cs) -> Ok (finish_single_complete w, cs)
           | _ as ret -> Ok ret
 


### PR DESCRIPTION
this fixes #21:
```OCaml
# Uni<tab>
  Unix_cstruct : 
  Unit : (module Stdlib__unit)
  Unix : 
  UnixLabels : 
# Uni
```

the issue was mainly the `String.trim cs` in `id_complete` (which ate too much, namely all the whitespaces and the tab of the last completion), but then I needed a way to skip the last empty line (by enhancing `Txt.lines` with an optional named `empty` argument, similar to `Astring.String.cuts`).