### PR TITLE
Upgrade to OCaml 4.14

### DIFF
--- a/opam
+++ b/opam
@@ -16,7 +16,7 @@ depends: [
 depopts: []
 build: [
   "ocaml" "pkg/pkg.ml" "build"
-          "--dev-pkg" "%{pinned}%"
+          "--dev-pkg" "%{dev}%"
           "--lib-dir" "%{lib}%" ]
 
 # Following is only to deal with

--- a/opam
+++ b/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/dbuenzli/down/issues"
 tags: [ "org:erratique" "dev" "toplevel" "repl" ]
 available: [ ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.14.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.1" } ]

--- a/src/down.ml
+++ b/src/down.ml
@@ -11,7 +11,7 @@ open Down_std
 module type TOP = sig
   val read_interactive_input : (string -> bytes -> int -> int * bool) ref
   val use_file : Format.formatter -> string -> bool
-  val use_silently : Format.formatter -> string -> bool
+  val use_silently : Format.formatter -> Toploop.input -> bool
 end
 
 module Nil = struct
@@ -28,7 +28,7 @@ let original_ocaml_readline = ref (fun _ _ _ -> assert false)
 let use_file ?(silent = false) file =
   let module Top = (val !top : TOP) in
   match silent with
-  | true -> Top.use_silently Format.std_formatter file
+  | true -> Top.use_silently Format.std_formatter (Toploop.File file)
   | false -> Top.use_file Format.std_formatter file
 
 (* Logging and formatting styles *)

--- a/src/down.mli
+++ b/src/down.mli
@@ -112,7 +112,7 @@ module Private : sig
   module type TOP = sig
     val read_interactive_input : (string -> bytes -> int -> int * bool) ref
     val use_file : Format.formatter -> string -> bool
-    val use_silently : Format.formatter -> string -> bool
+    val use_silently : Format.formatter -> Toploop.input -> bool
   end
 
   val set_top : (module TOP) -> unit


### PR DESCRIPTION
https://github.com/ocaml/ocaml/pull/10438 changed the interface of `Toploop.use_silently`. I’m not sure if/how you want to keep compatibility with earlier versions of the compiler but at the very least here is a PR for those of us who want to use OCaml 4.14 right away and need a usable REPL ^^"