### PR TITLE
Initial support for Win32

### DIFF
--- a/src/down.ml
+++ b/src/down.ml
@@ -994,7 +994,7 @@ let down_readline p =
 external sigwinch : unit -> int = "ocaml_down_sigwinch"
 let install_sigwinch_interrupt () =
   (* Sufficient to interrupt the event loop on window size changes. *)
-  Sys.set_signal (sigwinch ()) (Sys.Signal_handle (fun _ -> ()))
+  if Sys.unix then Sys.set_signal (sigwinch ()) (Sys.Signal_handle (fun _ -> ()))
 
 let pp_announce ppf () =
   Fmt.pf ppf "%a %%VERSION%% loaded. Type %a for more info."

--- a/src/down.ml
+++ b/src/down.ml
@@ -618,7 +618,9 @@ module Prompt = struct
     | false -> acc
     in
     let ui = String.concat "" (List.rev acc) in
+    p.output Tty.cursor_hide;
     clear_ui p; p.output ui;
+    p.output Tty.cursor_show;
     if active then (p.last_cr <- cr; p.last_max_r <- max_r)
 
   let render_id_complete p prefix candidates =

--- a/src/down_std.ml
+++ b/src/down_std.ml
@@ -439,6 +439,8 @@ module Tty = struct
   let cursor_forward n =
     if n = 0 then "" else String.concat "" ["\x1B["; string_of_int n; "C"]
 
+  let cursor_hide = "\x1B[?25l"
+  let cursor_show = "\x1B[?25h"
   let cursor_origin = "\x1B[H"
   let clear_screen = "\x1B[2J"
 

--- a/src/down_std.mli
+++ b/src/down_std.mli
@@ -294,6 +294,12 @@ module Tty : sig
   val cursor_forward : int -> string
   (** [cursor_forward n] moves cursor by [n] columns. *)
 
+  val cursor_hide : string
+  (** [cursor_hide] hides the cursor. *)
+
+  val cursor_show : string
+  (** [cursor_show] shows the cursor. *)
+
   val cursor_origin : string
   (** [cursor_origin] moves cursor to the top-left origin. *)
 

--- a/src/down_stubs.c
+++ b/src/down_stubs.c
@@ -19,7 +19,7 @@ static HANDLE hError = INVALID_HANDLE_VALUE;
 CAMLprim value ocaml_down_stdin_set_raw_mode (value set_raw)
 {
   static DWORD hOrigInputMode, hOrigOutputMode, hOrigErrorMode;
-  static bool is_raw = FALSE;
+  static BOOL is_raw = FALSE;
   DWORD hRawInputMode = ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_WINDOW_INPUT;
   DWORD hRawOutputMode = ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
@@ -50,9 +50,9 @@ CAMLprim value ocaml_down_stdin_set_raw_mode (value set_raw)
     }
   } else {
     if (is_raw) {
-      if (SetConsoleMode(hInput, hOrigInputMode | hRawInputMode) == 0 ||
-          SetConsoleMode(hOutput, hOrigOutputMode | hRawOutputMode) == 0 ||
-          SetConsoleMode(hInput, hOrigErrorMode | hRawOutputMode) == 0) {
+      if (SetConsoleMode(hInput, hOrigInputMode) == 0 ||
+          SetConsoleMode(hOutput, hOrigOutputMode) == 0 ||
+          SetConsoleMode(hInput, hOrigErrorMode) == 0) {
         return Val_bool(0);
       }
 


### PR DESCRIPTION
See the discussion in #34.

The list of things that do not work is long: resize events, mouse events, completion (tab) makes it go completely haywire, etc. But the bare minimum works. I did it before @jonahbeckford revealed his previous work, so things are done somewhat differently and/or in an overly naïve way (but note that with this simple patch arrows keys **do** work).

I don't think this patch is good enough to claim that Down works on Windows, but may serve as a stepping stone for further improvements.

I leave some comments inline below.